### PR TITLE
Geography.py missing import

### DIFF
--- a/TileStache/Geography.py
+++ b/TileStache/Geography.py
@@ -33,7 +33,7 @@ You can also instantiate a projection class using this syntax:
 """
 
 from ModestMaps.Core import Point, Coordinate
-from ModestMaps.Geo import deriveTransformation, MercatorProjection, LinearProjection
+from ModestMaps.Geo import deriveTransformation, MercatorProjection, LinearProjection, Location
 from math import log as _log, pi as _pi
 
 import Core


### PR DESCRIPTION
 Geography.py was missing import of ModestMaps.Geo Location, used by class WGS84(linearProjection)

I ran into this while putting together a SpliteGeoJSON based on PostGeoJSON, and using EPSG4826 instead of 900913/3857.
