### PR TITLE
Mapnik Grid format support

### DIFF
--- a/TileStache/Goodies/Providers/MapnikGrid.py
+++ b/TileStache/Goodies/Providers/MapnikGrid.py
@@ -1,17 +1,32 @@
 """ Mapnik UTFGrid Provider.
+Takes the first layer from the given mapnik xml file and renders it as UTFGrid
+https://github.com/mapbox/mbtiles-spec/blob/master/1.1/utfgrid.md
+It can then be used for this:
+http://mapbox.github.com/wax/interaction-leaf.html
 Only works with mapnik2 (Where the Grid functionality was introduced)
+
+Use Sperical Mercator projection and the extension "json"
 
 Sample configuration:
 
     "provider":
     {
       "class": "TileStache.Goodies.Providers.MapnikGrid:Provider",
-      "kwargs": { "mapfile": "mymap.xml", "fields":["name","address"] }
+      "kwargs":
+      {
+        "mapfile": "mymap.xml", 
+        "fields":["name","address"],
+        "layer_index": 0,
+        "wrapper": "grid",
+        "scale": 4
+      }
     }
 
 mapfile: the mapnik xml file to load the map from
 fields: The fields that should be added to the resulting grid json.
-
+layer_index: The index of the layer you want from your map xml to be rendered
+wrapper: If not included the json will be output raw, if included the json will be wrapped in "wrapper(JSON)" (for use with wax)
+scale: What to divide the tile pixel size by to get the resulting grid size. Usually this is 4.
 """
 import json
 import mapnik2 as mapnik
@@ -19,12 +34,15 @@ from TileStache.Geography import getProjectionByName
 
 class Provider:
 
-    def __init__(self, layer, mapfile, fields):
+    def __init__(self, layer, mapfile, fields, layer_index=0, wrapper=None, scale=4):
         """
         """
         self.mapnik = None
         self.layer = layer
         self.mapfile = mapfile
+        self.layer_index = layer_index
+        self.wrapper = wrapper
+        self.scale = scale
         #De-Unicode the strings or mapnik gets upset
         self.fields = list(str(x) for x in fields)
 
@@ -50,11 +68,14 @@ class Provider:
         # create grid as same size as map/image
         grid = mapnik.Grid(width, height)
         # render a layer to that grid array
-        mapnik.render_layer(self.mapnik,grid,layer=0,fields=self.fields)
-        # then encode the grid array as utf, resample to 1/4 the size, and dump features
-        grid_utf = grid.encode('utf',resolution=4,add_features=True)
+        mapnik.render_layer(self.mapnik,grid,layer=self.layer_index,fields=self.fields)
+        # then encode the grid array as utf, resample to 1/scale the size, and dump features
+        grid_utf = grid.encode('utf',resolution=self.scale,add_features=True)
 
-        return SaveableResponse('grid(' + json.dumps(grid_utf) + ')')
+        if self.wrapper is None:
+                return SaveableResponse(json.dumps(grid_utf))
+        else:
+                return SaveableResponse(self.wrapper + '(' + json.dumps(grid_utf) + ')')
 
     def getTypeByExtension(self, extension):
         """ Get mime-type and format by file extension.


### PR DESCRIPTION
Hi Guys.

I've implemented a Provider for UTFGrid via mapnik grid_renderer.

http://trac.mapnik.org/wiki/MapnikRenderers#grid_renderer
https://github.com/mapbox/mbtiles-spec/blob/master/1.1/utfgrid.md

This allows you to use TileStache to serve up grid json for consumption by wax, like on http://mapbox.github.com/wax/interaction-leaf.html

Hopefully everything is up to scratch :-)
