### PR TITLE
Ignore missing lock directories when unlocking

### DIFF
--- a/TileStache/Caches.py
+++ b/TileStache/Caches.py
@@ -253,7 +253,11 @@ class Disk:
             Lock is implemented as an empty directory next to the tile file.
         """
         lockpath = self._lockpath(layer, coord, format)
-        os.rmdir(lockpath)
+        try:
+            os.rmdir(lockpath)
+        except OSError:
+            # Ok, someone else deleted it already
+            pass
     
     def read(self, layer, coord, format):
         """ Read a cached tile.


### PR DESCRIPTION
Under some circumstances (for example when a provider takes longer time than the layer's stale lock timeout), you can end up in a form of race condition where a request's lock directory is already deleted when it tries to unlock.

In this case, it's better to just silently continue instead of failing the request just because the lock couldn't be removed.
