### PR TITLE
Make import consistent with the built-in mapnik provider

### DIFF
--- a/TileStache/Goodies/Providers/MapnikGrid.py
+++ b/TileStache/Goodies/Providers/MapnikGrid.py
@@ -33,9 +33,12 @@ import json
 from TileStache.Geography import getProjectionByName
 
 try:
-    import mapnik
+    import mapnik2 as mapnik
 except ImportError:
-    pass
+    try:
+        import mapnik
+    except ImportError:
+        pass
 
 class Provider:
 


### PR DESCRIPTION
This makes the MapnikGrid provider backwards compatible with the stable 2.0.0 mapnik release.
