### PR TITLE
Preview template update to get touch working in iOS (again?)

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -546,19 +546,31 @@ def _preview(layer):
 <head>
     <title>TileStache Preview: %(layername)s</title>
     <script src="http://code.modestmaps.com/tilestache/modestmaps.min.js" type="text/javascript"></script>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0;" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0;">
+    <style type="text/css">
+        html, body, #map {
+            position: absolute;
+            width: 100%%;
+            height: 100%%;
+            margin: 0;
+            padding: 0;
+        }
+    </style>
 </head>
-<body style="position: absolute; width: 100%%; height: 100%%;">
-    <script type="text/javascript">
+<body>
+    <div id="map"></div>
+    <script type="text/javascript" defer>
     <!--
-    
         var template = '{Z}/{X}/{Y}.%(ext)s';
         var provider = new com.modestmaps.TemplatedMapProvider(template);
-        var map = new MM.Map(document.body, provider);
+        var map = new MM.Map('map', provider, null, [
+            new MM.TouchHandler(),
+            new MM.DragHandler(),
+            new MM.DoubleClickHandler()
+        ]);
         map.setCenterZoom(new com.modestmaps.Location(%(lat).6f, %(lon).6f), %(zoom)d);
         // hashify it
         new MM.Hash(map);
-    
     //-->
     </script>
 </body>


### PR DESCRIPTION
Not sure when this stopped working, but Nate and I took a look on phones and pads last night and it was clearly broken for two reasons:
1. The `<body>` doesn't have a computed width and height when the script executes, so the map doesn't either.
2. The build of MM that we're using didn't create a `TouchHandler` by default, so touch interaction wasn't enabled.

This commit fixes both issues by putting the map into its own `<div>`, explicitly setting the width and height of everything on the page to 100% (and with absolute positioning) in CSS, and deferring the script execution until after the DOM is ready with a `defer` attribute. This is rock-solid on every browser that I've checked, including Firefox, which is notoriously bad about respecting `height: 100%`.
