### PR TITLE
Re-Add PIL import to Providers.py

### DIFF
--- a/TileStache/Providers.py
+++ b/TileStache/Providers.py
@@ -88,6 +88,12 @@ except ImportError:
         # if you don't plan to use the mapnik provider.
         pass
 
+try:
+    from PIL import Image
+except ImportError:
+    # On some systems, PIL.Image is known as Image.
+    import Image
+
 import ModestMaps
 from ModestMaps.Core import Point, Coordinate
 


### PR DESCRIPTION
Providers.py calls Image.open but hasn't imported PIL, so it doesn't work.
This re-adds the PIL import so it does.
