### PR TITLE
Correction to Composite Provider example config

### DIFF
--- a/examples/composite/composite.cfg
+++ b/examples/composite/composite.cfg
@@ -26,8 +26,21 @@
     },
     "composite":
     {
-        "provider": {"class": "TileStache.Goodies.Providers.Composite:Provider",
-                     "kwargs": {"stackfile": "composite-stack.xml"}}
+        "provider": {
+            "class": "TileStache.Goodies.Providers.Composite:Provider",
+            "kwargs":
+            {
+                "stack":
+                [
+                  {"src": "base"},
+                  [
+                    {"src": "outlines", "mask": "halos"},
+                    {"src": "streets"}
+                  ]
+                ]
+            }
+        }
+
     }
   }
 }


### PR DESCRIPTION
Content taken from Goodies/Providers/Composite.py
