### PR TITLE
print a better error if you start tilestache-server with an invalid config

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -371,8 +371,9 @@ class WSGITileServer:
     
             try:
                 self.config = parseConfigfile(config)
-            except Exception, e:
-                raise Core.KnownUnknown("Error loading Tilestache config file:\n%s" % str(e))
+            except:
+                print "Error loading Tilestache config:"
+                raise
 
         else:
             assert hasattr(config, 'cache'), 'Configuration object must have a cache.'


### PR DESCRIPTION
Currently, if you have an invalid config file (like, say you forgot to install python-mapnik on an ubuntu server, as happened to me a few hours ago), you get an error message, but not a helpful traceback.

This patch improves that situation by not swallowing the error on server startup.

before:

```
$ tilestache-server.py invalid.cfg
Traceback (most recent call last):
  File "/usr/local/share/python/tilestache-server.py", line 55, in <module>
    app = TileStache.WSGITileServer(config=options.file, autoreload=True)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/__init__.py", line 297, in __init__
    raise Core.KnownUnknown("Error loading Tilestache config file:\n%s" % str(e))
TileStache.Core.KnownUnknown: Error loading Tilestache config file:
global name 'mapnik' is not defined
```

after:

```
$ tilestache-server.py invalid.cfg
Error loading Tilestache config:
Traceback (most recent call last):
  File "scripts/tilestache-server.py", line 55, in <module>
    app = TileStache.WSGITileServer(config=options.file, autoreload=True)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/__init__.py", line 295, in __init__
    self.config = parseConfigfile(config)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/__init__.py", line 149, in parseConfigfile
    return Config.buildConfiguration(config_dict, dirpath)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/Config.py", line 115, in buildConfiguration
    config.layers[name] = _parseConfigfileLayer(layer_dict, config, dirpath)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/Config.py", line 317, in _parseConfigfileLayer
    layer.provider = _class(layer, **provider_kwargs)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/TileStache/Providers.py", line 236, in __init__
    engine = mapnik.FontEngine.instance()
NameError: global name 'mapnik' is not defined
```
