### PR TITLE
Specify UTF encoding in JSON tiles content-type

### DIFF
--- a/TileStache/Goodies/Providers/MapnikGrid.py
+++ b/TileStache/Goodies/Providers/MapnikGrid.py
@@ -109,7 +109,7 @@ class Provider:
         if extension.lower() != 'json':
             raise KnownUnknown('MapnikGrid only makes .json tiles, not "%s"' % extension)
 
-        return 'application/json', 'JSON'
+        return 'application/json; charset=utf-8', 'JSON'
 
 class SaveableResponse:
     """ Wrapper class for JSON response that makes it behave like a PIL.Image object.

--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -241,7 +241,7 @@ class GridProvider:
         if extension.lower() != 'json':
             raise KnownUnknown('MapnikGrid only makes .json tiles, not "%s"' % extension)
 
-        return 'application/json', 'JSON'
+        return 'application/json; charset=utf-8', 'JSON'
 
 class SaveableResponse:
     """ Wrapper class for JSON response that makes it behave like a PIL.Image object.

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -287,7 +287,7 @@ def requestHandler(config_hint, path_info, query_string):
             mimetype, content = getTile(layer, coord, extension)
     
         if callback and 'json' in mimetype:
-            mimetype, content = 'application/javascript', '%s(%s)' % (callback, content)
+            mimetype, content = 'application/javascript; charset=utf-8', '%s(%s)' % (callback, content)
 
     except Core.KnownUnknown, e:
         out = StringIO()


### PR DESCRIPTION
As there were no encoding specified in json/jsonp responses, my chromium browser incorrectly interpreted them as latin1 and displayed broken non-latin field values.
