### PR TITLE
Remove references to old mapnik2 namespace

### DIFF
--- a/TileStache/Goodies/Providers/MapnikGrid.py
+++ b/TileStache/Goodies/Providers/MapnikGrid.py
@@ -4,7 +4,7 @@ Takes the first layer from the given mapnik xml file and renders it as UTFGrid
 https://github.com/mapbox/utfgrid-spec/blob/master/1.2/utfgrid.md
 It can then be used for this:
 http://mapbox.github.com/wax/interaction-leaf.html
-Only works with mapnik2 (Where the Grid functionality was introduced)
+Only works with mapnik>=2.0 (Where the Grid functionality was introduced)
 
 Use Sperical Mercator projection and the extension "json"
 
@@ -36,12 +36,9 @@ from TileStache.Geography import getProjectionByName
 from urlparse import urlparse, urljoin
 
 try:
-    import mapnik2 as mapnik
+    import mapnik
 except ImportError:
-    try:
-        import mapnik
-    except ImportError:
-        pass
+    pass
 
 class Provider:
 

--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -16,6 +16,7 @@ from urllib import urlopen
 import os
 import logging
 import json
+import mapnik
 
 from TileStache.Core import KnownUnknown
 from TileStache.Geography import getProjectionByName
@@ -25,12 +26,6 @@ try:
 except ImportError:
     # On some systems, PIL.Image is known as Image.
     import Image
-
-try:
-    import mapnik
-except ImportError:
-    # mapnik 2.0.0 is known as mapnik2
-    import mapnik2 as mapnik
 
 if 'mapnik' in locals():
     _version = hasattr(mapnik, 'mapnik_version') and mapnik.mapnik_version() or 701


### PR DESCRIPTION
Everything should point to the `mapnik` module at this point. 

The `mapnik2` is not just unnecessary, it can cause problems with the pre-utfgrid versions. See my comments in #42. 
