### PR TITLE
Force modestmaps preview to 256x256 tile dimensions

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -598,6 +598,11 @@ def _preview(layer):
             margin: 0;
             padding: 0;
         }
+
+        #map img {
+            width: 256px;
+            height: 256px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
When using tiles with a `tile height` of something other than 256px, the builtin preview got all wonky.  The tiles were being rendered at their native size but modestmaps was arranging them in a typical 256px layout.  So if you have 512px retina tiles, they would overlap.

This is a pretty dirty hack to constrain the images to the 256x256 layout that modestmaps uses (and display retina tiles properly).
