### PR TITLE
Update getTile callers to use new signature

### DIFF
--- a/TileStache/Goodies/Providers/Composite.py
+++ b/TileStache/Goodies/Providers/Composite.py
@@ -314,7 +314,7 @@ class Layer:
     
         if self.layername:
             layer = config.layers[self.layername]
-            mime, body = TileStache.getTile(layer, coord, 'png')
+            _, _, body = TileStache.getTile(layer, coord, 'png')
             layer_img = Image.open(StringIO(body)).convert('RGBA')
             layer_rgba = _img2rgba(layer_img)
 
@@ -322,7 +322,7 @@ class Layer:
         
         if self.maskname:
             layer = config.layers[self.maskname]
-            mime, body = TileStache.getTile(layer, coord, 'png')
+            _, _, body = TileStache.getTile(layer, coord, 'png')
             mask_img = Image.open(StringIO(body)).convert('L')
             mask_chan = _img2arr(mask_img).astype(numpy.float32) / 255.
 

--- a/TileStache/Goodies/Providers/UtfGridComposite.py
+++ b/TileStache/Goodies/Providers/UtfGridComposite.py
@@ -66,7 +66,7 @@ class Provider:
 
 	def addLayer( self, layerDef, coord ):
 		
-		layer = TileStache.getTile(self.layer.config.layers[layerDef['src']], coord, 'JSON')[1]
+		_, _, layer = TileStache.getTile(self.layer.config.layers[layerDef['src']], coord, 'JSON')[1]
 #		raise KnownUnknown(layer)
 		if layerDef['wrapper'] == None:
 			layer = json.loads(layer)

--- a/TileStache/Sandwich.py
+++ b/TileStache/Sandwich.py
@@ -276,7 +276,7 @@ def layer_bitmap(layer, coord):
     """
     from . import getTile
 
-    mime, body = getTile(layer, coord, 'png')
+    _, _, body = getTile(layer, coord, 'png')
     image = Image.open(StringIO(body)).convert('RGBA')
 
     return Blit.Bitmap(image)

--- a/scripts/tilestache-compose.py
+++ b/scripts/tilestache-compose.py
@@ -46,7 +46,7 @@ class Provider (ModestMaps.Providers.IMapProvider):
         """ Return tile URLs that start with file://, by first retrieving them.
         """
         if self.threadsafe or self.lock.acquire():
-            mime_type, tile_data = TileStache.getTile(self.layer, coord, 'png', self.ignore_cached)
+            _, _, tile_data = TileStache.getTile(self.layer, coord, 'png', self.ignore_cached)
             
             handle, filename = mkstemp(prefix='tilestache-compose-', suffix='.png')
             write(handle, tile_data)

--- a/scripts/tilestache-render.py
+++ b/scripts/tilestache-render.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     
     for coord in coords:
         # render
-        mimetype, content = getTile(layer, coord, extension)
+        _, _, content = getTile(layer, coord, extension)
         
         # save
         handle, filename = mkstemp(prefix='tile-', suffix='.'+extension)

--- a/scripts/tilestache-seed.py
+++ b/scripts/tilestache-seed.py
@@ -328,7 +328,8 @@ if __name__ == '__main__':
                 print >> stderr, '%(offset)d of %(total)d...' % progress,
     
             try:
-                mimetype, content = getTile(layer, coord, extension, options.ignore_cached)
+                status_code, headers, content = getTile(layer, coord, extension, options.ignore_cached)
+                mimetype = headers['Content-Type']
                 
                 if 'json' in mimetype and options.callback:
                     js_path = '%s/%d/%d/%d.js' % (layer.name(), coord.zoom, coord.column, coord.row)


### PR DESCRIPTION
Oops.  FWIW, it looks like the `UtfGridComposite` provider may have already been broken?

Fixes #120.
