### PR TITLE
fix documentation bug: `True` is invalid JSON but `true` is not

### DIFF
--- a/API.html
+++ b/API.html
@@ -440,7 +440,7 @@ Example configuration:
 <span class="bg">{</span>
   "cache": {
     "name": "Test",
-    "verbose": True
+    "verbose": true
   }<span class="bg">,
   "layers": { … }
 }</span>

--- a/TileStache/Caches.py
+++ b/TileStache/Caches.py
@@ -94,7 +94,7 @@ class Test:
 
             "cache": {
               "name": "Test",
-              "verbose": True
+              "verbose": true
             }
 
         Extra configuration parameters:


### PR DESCRIPTION
These are the only two instances where I found that doc bug.
