### PR TITLE
Properly transform a location into a coordinate when using a Proj4 projection

### DIFF
--- a/TileStache/Goodies/Proj4Projection.py
+++ b/TileStache/Goodies/Proj4Projection.py
@@ -94,6 +94,11 @@ class Proj4Projection(LinearProjection):
         p.x = p.x / scale
         p.y = p.y / scale
         return p
+
+    def locationCoordinate(self, location):
+        point = self.locationProj(location)
+        point = self.project(point, 1.0 / self.tile_dimensions[self.zoom])
+        return Coordinate(point.y, point.x, self.zoom)
         
     def coordinateProj(self, coord):
         """Convert from Coordinate object to a Point object in the defined projection"""


### PR DESCRIPTION
This is the start of a solution for [Issue #80](https://github.com/migurski/TileStache/issues/80). As `Goodies.Proj4Projection.Proj4Projection.project()` overloads `ModestMaps.Geo.LinearProjection.project()` and adds another argument to the function (`scale`), the original calls to `project()` do not work any longer, for example `ModestMaps.Geo.locationCoordinate()`, which is used in `tilestache-seed.py`.

I added an overload for `locationCoordinate()` to `Goodies.Proj4Projection.Proj4Projection`, which resolves the problem at least in my case. Apart from my EPSG:3035 use case, the patch is untested. Probably one should add a similar overload for `coordinateLocation()` so that the issue is resolved in the other direction as well.
