### PR TITLE
Replaced requestHandler() with requestHandler2()

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -397,6 +397,8 @@ class WSGITileServer:
 def modpythonHandler(request):
     """ Handle a mod_python request.
     
+        TODO: Upgrade to new requestHandler() so this can return non-200 HTTP.
+    
         Calls requestHandler().
     
         Example Apache configuration for TileStache:


### PR DESCRIPTION
@mojodna, I’m interested in your particular input here.

This work is intended to bring `requestHandler()` back inline with [the docs](http://tilestache.org/doc/#tilestache-requesthandler).
