### PR TITLE
Add new GeoPack format for VecTiles

### DIFF
--- a/TileStache/Goodies/VecTiles/geopack.py
+++ b/TileStache/Goodies/VecTiles/geopack.py
@@ -33,7 +33,7 @@ def get_tiles(names, config, coord):
     
     layers = [config.layers[name] for name in names]
     mimes, bodies = zip(*[getTile(layer, coord, 'geopack') for layer in layers])
-    bad_mimes = [(name, mime) for (mime, name) in zip(mimes, names) if not mime == 'application/msgpack']
+    bad_mimes = [(name, mime) for (mime, name) in zip(mimes, names) if not mime == 'application/x-msgpack']
     
     if bad_mimes:
         raise KnownUnknown('%s.get_tiles encountered a non-plaintext mime-type in %s sub-layer: "%s"' % ((__name__, ) + bad_mimes[0]))

--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -170,7 +170,7 @@ class Provider:
             return 'application/json', 'TopoJSON'
         
         elif extension.lower() == 'geopack':
-            return 'application/msgpack', 'GeoPack'
+            return 'application/x-msgpack', 'GeoPack'
         
         else:
             raise ValueError(extension)
@@ -214,7 +214,7 @@ class MultiProvider:
             return 'application/json', 'TopoJSON'
         
         elif extension.lower() == 'geopack':
-            return 'application/msgpack', 'GeoPack'
+            return 'application/x-msgpack', 'GeoPack'
         
         else:
             raise ValueError(extension)


### PR DESCRIPTION
GeoPack is a small adjustment to [TopoJSON](https://github.com/mbostock/topojson) encoded with binary [MessagePack](http://msgpack.org) for parsing speed and intended for use with larger, metatile payloads and potential whole-world renders. This pull is in-progress.

Todo:
- [ ] Add unit tests.
- [ ] Decide whether to stick with geographic coordinates (see commit 6baaa0bc7612)
- [ ] Benchmark encoding speed.
