### PR TITLE
Add option to allow spherical mercator in GeoJSON

### DIFF
--- a/TileStache/Goodies/VecTiles/geojson.py
+++ b/TileStache/Goodies/VecTiles/geojson.py
@@ -70,7 +70,7 @@ def decode(file):
     
     return features
 
-def encode(file, features, zoom, is_clipped):
+def encode(file, features, zoom, is_clipped, crs_name=None):
     ''' Encode a list of (WKB, property dict) features into a GeoJSON stream.
     
         Also accept three-element tuples as features: (WKB, property dict, id).
@@ -91,6 +91,9 @@ def encode(file, features, zoom, is_clipped):
             feature.update(dict(clipped=True))
     
     geojson = dict(type='FeatureCollection', features=features)
+    if crs_name is not None:
+        geojson['crs'] = {'type': 'name', 'properties': {'name': crs_name}}
+
     encoder = json.JSONEncoder(separators=(',', ':'))
     encoded = encoder.iterencode(geojson)
     flt_fmt = '%%.%df' % precisions[zoom]


### PR DESCRIPTION
Introduce an optional boolean flag 'project_geojson' for the VecTiles provider
that allows geometries to remain in spherical mercator rather than project
them to 4326.  Defaults to false and does affect already existing config
files.

In the project I work on, we have an iphone app rendering GeoJSON-formatted vector tiles, where the coordinates are already in spherical mercator.  This commit saves the database from projecting to lat/lon and the phone re-projecting back to spherical mercator.

In the future I can try to add this option to the MultiProvider, allowing it to override this flag on the individual layers.  It's more difficult as it would have to pass down the option to the individual layers at init time. I haven't tried to tackle it yet before getting feedback on this.

Update:
After reading some discussion in the comments here: http://mike.teczno.com/notes/postgreslessness-mapnik-vectiles.html as well as the spec at geojson.org, I added the 'crs' field to the FeatureCollection when the data is sent projected.  

The SRID's authority is obtained by querying srid_auth from spatial_ref_sys.  This happens on **init** in server.py's Provider.
