### PR TITLE
Return empty response for queries with no features

### DIFF
--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -151,11 +151,17 @@ class Provider:
             return EmptyResponse(bounds)
         
         if query not in self.columns:
-            self.columns[query] = query_columns(self.dbinfo, self.srid, query, bounds)
+            columns = query_columns(self.dbinfo, self.srid, query, bounds)
+            self.columns[query] = columns
+        else:
+            columns = self.columns[query]
+
+        if columns is None:
+            return EmptyResponse(bounds)
         
         tolerance = self.simplify * tolerances[coord.zoom] if coord.zoom < self.simplify_until else None
         
-        return Response(self.dbinfo, self.srid, query, self.columns[query], bounds, tolerance, coord.zoom, self.clip)
+        return Response(self.dbinfo, self.srid, query, columns, bounds, tolerance, coord.zoom, self.clip)
 
     def getTypeByExtension(self, extension):
         ''' Get mime-type and format by file extension, one of "mvt", "json" or "topojson".
@@ -357,6 +363,8 @@ def query_columns(dbinfo, srid, subquery, bounds):
             
             column_names = set(row.keys())
             return column_names
+
+        return None
         
 def build_query(srid, subquery, subcolumns, bbox, tolerance, is_geo, is_clipped):
     ''' Build and return an PostGIS query.


### PR DESCRIPTION
If query_columns() finds no features, the columns can't be determined causing
a crash.  Explicitly return None for the columns and generate an
EmptyResponse.

I found this bug when I had a typo in a query causing no features to be found in query_columns as it zooms out looking for them.  I figured returning an EmptyResponse rather than raising an exception is the right thing here.
