### PR TITLE
Add 'scale factor' option to Mapnik image provider

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -61,8 +61,8 @@ class ImageProvider:
         - fonts (optional)
             Local directory path to *.ttf font files.
 
-        - scale_factor (optional)
-            Scale multiplier used for Mapnik rendering pipeline. Used used for
+        - "scale factor" (optional)
+            Scale multiplier used for Mapnik rendering pipeline. Used for
             supporting retina resolution.
 
             For more information about the scale factor, see: 


### PR DESCRIPTION
Adds the optional 'scale factor' argument in the config for Mapnik's
image provider. Allows a TileStache layer to be configured for retina.

This allows specifying the 'scale_factor' option the ImageProvider. It's used to render retina tiles.

For discussions about it, see:
https://github.com/mapnik/mapnik/wiki/Scale-factor
http://support.mapbox.com/discussions/mapbox-ios-sdk/275-retina-maps-for-completely-custom-style
https://groups.google.com/forum/#!topic/mapnik/g4MiIZu9SCk
