### PR TITLE
Fix the dependencies for ubuntugis-unstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ virtualenv:
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get update -qq
-  - sudo apt-get install -qq postgis gdal-bin libgdal-dev libgdal1 libgdal1-dev libpq-dev memcached python-pip
+  - sudo apt-get install -qq gdal-bin postgresql-9.1-postgis-2.0 memcached python-pip
   - sudo apt-get install -qq python-nose python-imaging python-memcache python-gdal
   - sudo apt-get install -qq python-coverage python-werkzeug python-psycopg2
   - ogrinfo --version


### PR DESCRIPTION
Fixes the Travis CI script. Dependency problems arose from packages renamed
on ubuntugis-unstable

On unstable, libgdal1 was renamed to libgdal1h. This is why the build stopped working even though the Travis-CI script hadn't changed. Other packages were renamed as well. Using postgresql-0.1-postgis-2.0 gets things working again. Alternatively, using the stable ppa would work.

See discussions:
http://lists.osgeo.org/pipermail/ubuntu/2013-July/000756.html
