### PR TITLE
Add 'Access-Control-Allow-Origin' to header in requestHandler2

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -253,6 +253,8 @@ def requestHandler2(config_hint, path_info, query_string=None, script_name=''):
         
         else:
             status_code, headers, content = layer.getTileResponse(coord, extension)
+            if layer.allowed_origin:
+                headers.setdefault('Access-Control-Allow-Origin', layer.allowed_origin)
     
         if callback and 'json' in headers['Content-Type']:
             headers['Content-Type'] = 'application/javascript; charset=utf-8'


### PR DESCRIPTION
In `requestHandler2()`, the allowed_origin parameter for a given layer is successfully parsed, and inserted into an instance of wsgiref.headers Headers class.

However the variable `headers` is overwritten upon a successful return from `layer.getTileResponse()`. This removes the value a user has provided for the "allowed origins" parameter for a layer within the TileStache config.
