### PR TITLE
Links to PIL documentation for image settings are broken

### DIFF
--- a/API.html
+++ b/API.html
@@ -961,7 +961,7 @@ Shared layer parameters:
     <dt>jpeg options</dt>
     <dd>
     An optional dictionary of JPEG creation options, passed through
-    <a href="http://www.pythonware.com/library/pil/handbook/format-jpeg.htm">to PIL</a>.
+    <a href="http://effbot.org/imagingbook/format-jpeg.htm">to PIL</a>.
     Valid options include <var>quality</var> (integer), <var>progressive</var>
     (boolean), and <var>optimize</var> (boolean).
     </dd>
@@ -969,7 +969,7 @@ Shared layer parameters:
     <dt>png options</dt>
     <dd>
     An optional dictionary of PNG creation options, passed through
-    <a href="http://www.pythonware.com/library/pil/handbook/format-png.htm">to PIL</a>.
+    <a href="http://effbot.org/imagingbook/format-png.htm">to PIL</a>.
     Valid options include <var>palette</var> (URL or filename), <var>palette256</var>
 	(boolean) and <var>optimize</var> (boolean).
     </dd>
@@ -1958,7 +1958,7 @@ Arguments to <code>renderTile</code>:
 
 <p>
 Return value of <code>renderTile</code> is a
-<a href="http://www.pythonware.com/library/pil/handbook/image.htm#Image.save"><code>PIL.Image</code></a>
+<a href="http://effbot.org/imagingbook/image.htm#Image.save"><code>PIL.Image</code></a>
 or other saveable object, used like this:
 </p>
 
@@ -2030,7 +2030,7 @@ Arguments to <code>renderArea</code>:
 
 <p>
 Return value of <code>renderArea</code> is a
-<a href="http://www.pythonware.com/library/pil/handbook/image.htm#Image.save"><code>PIL.Image</code></a>
+<a href="http://effbot.org/imagingbook/image.htm#Image.save"><code>PIL.Image</code></a>
 or other saveable object, used like this:
 </p>
 

--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -70,9 +70,9 @@ configuration file as a dictionary:
   want to leave this at the default value of 256, but you can use a value of 512
   to create double-size, double-resolution tiles for high-density phone screens.
 - "jpeg options" is an optional dictionary of JPEG creation options, passed
-  through to PIL: http://www.pythonware.com/library/pil/handbook/format-jpeg.htm.
+  through to PIL: http://effbot.org/imagingbook/format-jpeg.htm.
 - "png options" is an optional dictionary of PNG creation options, passed
-  through to PIL: http://www.pythonware.com/library/pil/handbook/format-png.htm.
+  through to PIL: http://effbot.org/imagingbook/format-png.htm.
 
 The public-facing URL of a single tile for this layer might look like this:
 
@@ -621,7 +621,7 @@ class Layer:
         """ Optional arguments are added to self.jpeg_options for pickup when saving.
         
             More information about options:
-                http://www.pythonware.com/library/pil/handbook/format-jpeg.htm
+                http://effbot.org/imagingbook/format-jpeg.htm
         """
         if quality is not None:
             self.jpeg_options['quality'] = int(quality)
@@ -639,7 +639,7 @@ class Layer:
             and it implies bits and optional transparency options.
         
             More information about options:
-                http://www.pythonware.com/library/pil/handbook/format-png.htm
+                http://effbot.org/imagingbook/format-png.htm
         """
         if optimize is not None:
             self.png_options['optimize'] = bool(optimize)


### PR DESCRIPTION
PIL's been kinda dying on the vine for a while. Their documentation's still around, but they moved it all over to another domain without HTTP-302-ing it to the right place. So now the links are the working. For now...
