### PR TITLE
Return a transparent tile if coord is out of bounds.

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -468,7 +468,7 @@ class Layer:
             are mutually exclusive options
         """
         if self.bounds and self.bounds.excludes(coord):
-            raise NoTileLeftBehind(Image.new('RGB', (self.dim, self.dim), (0x99, 0x99, 0x99)))
+            raise NoTileLeftBehind(Image.new('RGBA', (self.dim, self.dim), (0, 0, 0, 0)))
         
         srs = self.projection.srs
         xmin, ymin, xmax, ymax = self.envelope(coord)


### PR DESCRIPTION
A layer can be configured with bounds, an optional dictionary of six tile boundaries to limit the rendered area. At the moment, however, a gray tile is returned if "coord" is out of bounds. Gray tiles, however, are not very useful if they are used as overlays or are part of a pixel sandwich: they will completely cover their background. For this reason, transparent tiles are returned if "coord" is out of bounds.
