### PR TITLE
Fix tile saved twice to cache.

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -430,7 +430,7 @@ class Layer:
                     tile.save(buff, format, **save_kwargs)
                     body = buff.getvalue()
                     
-                    if save:
+                    if save and not self.doMetatile():
                         cache.save(body, self, coord, format)
 
                     tile_from = 'layer.render()'


### PR DESCRIPTION
If self.doMetatile() returns True, the tile was already saved to cache while looping over all subtiles in the render method. No need for an extra round-trip to the caching backend.
