### PR TITLE
import mapnik imports Mapnik.py on case insensitive file systems

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -18,7 +18,8 @@ import logging
 import json
 
 try:
-    import mapnik
+    from importlib import import_module
+    mapnik = import_module('mapnik')
 except ImportError:
     # can still build documentation
     pass


### PR DESCRIPTION
at least it happens when ran on ubuntu vm guest on windows host
