### PR TITLE
adds headers config option for S3 cache

### DIFF
--- a/TileStache/Config.py
+++ b/TileStache/Config.py
@@ -308,7 +308,7 @@ def _parseConfigfileCache(cache_dict, dirpath):
             add_kwargs('host', 'port', 'db')
     
         elif _class is Caches.S3.Cache:
-            add_kwargs('bucket', 'access', 'secret', 'use_locks', 'path', 'reduced_redundancy')
+            add_kwargs('bucket', 'access', 'secret', 'use_locks', 'path', 'reduced_redundancy', 'headers')
     
         else:
             raise Exception('Unknown cache: %s' % cache_dict['name'])


### PR DESCRIPTION
'headers' is an optional metadata dictionary containing key/value header pairs that will be set on each saved tile, e.g. 

```
{
    "cache": {
        "name": "S3",
        ...
        "headers": {
            "Cache-Control": "max-age=25200, public"
        }
    },
    ...
}
```
