### PR TITLE
Update .travis.yml To Fix Broken Test Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - memcached
 
 before_install:
-#  - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+  - sudo rm /etc/apt/sources.list.d/ubuntugis-stable-source.list
   - sudo apt-get update -qq
   - sudo apt-get install -qq gdal-bin memcached python-pip
   - sudo apt-get install -qq python-nose python-imaging python-memcache python-gdal


### PR DESCRIPTION
Currently, the Travis-CI tests are breaking. Explicitly removing the reference to the `ubuntugis-stable` repository from Apt sources appears fix this problem. See: https://github.com/travis-ci/travis-ci/issues/2401

> We eventually tracked it down to the fact that the default build environment has both pgdg and ubuntugis-stable sources, and if you e.g. try and install python-gdal, this will uninstall the preinstalled postgresql-9.1-postgis-2.1 and libgdal1 (as that package is from pgdg and based upon GDAL 1.9) in order to install python-gdal and libgdal1h (from ubuntugis-stable and based upon GDAL 1.10). 
