### PR TITLE
fix Pillow dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 import pkg_resources
 import sys
 
@@ -19,10 +23,10 @@ def is_installed(name):
 requires = ['ModestMaps >=1.3.0','simplejson', 'Werkzeug']
 
 # Soft dependency on PIL or Pillow
-if is_installed('Pillow') or sys.platform == 'win32':
-    requires.append('Pillow')
-else:
+if is_installed('PIL'):
     requires.append('PIL')
+else:
+    requires.append('Pillow')
 
 
 setup(name='TileStache',


### PR DESCRIPTION
I think the whole "soft dependency" thing with PIL/Pillow should be the other way around. If you don't have any of them we should use the Pillow (de facto standard). If we already have PIL (as I see in Vagrant/setup.sh is installed in a seperate step) then we can use it. Also try to install this with setuptools first.

Without this fix you can't install TileStache right now. On a fresh virtualenv `pip install Pillow TileStache==1.49.11` gives:

```
Downloading/unpacking Pillow
  Downloading Pillow-2.6.1.tar.gz (7.3MB): 7.3MB downloaded
  Running setup.py (path:/tmp/test/build/Pillow/setup.py) egg_info for package Pillow

...
Downloading/unpacking TileStache==1.49.11
  Downloading TileStache-1.49.11.tar.gz (208kB): 208kB downloaded
  Running setup.py (path:/tmp/test/build/TileStache/setup.py) egg_info for package TileStache

Downloading/unpacking ModestMaps>=1.3.0 (from TileStache==1.49.11)
Downloading/unpacking simplejson (from TileStache==1.49.11)
Downloading/unpacking Werkzeug (from TileStache==1.49.11)
Downloading/unpacking PIL (from TileStache==1.49.11)
  Could not find any downloads that satisfy the requirement PIL (from TileStache==1.49.11)
  Some externally hosted files were ignored (use --allow-external PIL to allow).
Cleaning up...
No distributions at all found for PIL (from TileStache==1.49.11)
Storing debug log for failure in /home/slafs/.pip/pip.log
```
