### PR TITLE
enable "cache lifespan" in Redis cache

### DIFF
--- a/TileStache/Redis.py
+++ b/TileStache/Redis.py
@@ -113,4 +113,10 @@ class Cache:
         """ Save a cached tile.
         """
         key = tile_key(layer, coord, format, self.key_prefix)
-        self.conn.set(key, body)
+
+        # note: setting ex=0 will raise an error
+        cache_lifespan = layer.cache_lifespan
+        if cache_lifespan == 0:
+            cache_lifespan = None
+
+        self.conn.set(key, body, ex=cache_lifespan)


### PR DESCRIPTION
Using `SET <key> EX <seconds>`

For reference:
- http://redis.io/commands/set
- https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L1024
