### PR TITLE
Change modestmaps.min.js URL to be protocol relative

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -711,7 +711,7 @@ def _preview(layer):
 <html>
 <head>
     <title>TileStache Preview: %(layername)s</title>
-    <script src="http://code.modestmaps.com/tilestache/modestmaps.min.js" type="text/javascript"></script>
+    <script src="//dlmn0obhi5td1.cloudfront.net/tilestache/modestmaps.min.js" type="text/javascript"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0;">
     <style type="text/css">
         html, body, #map {


### PR DESCRIPTION
I found the Cloudfront URL with a `dig code.modestmaps.com`. I get that it may not be so good to hardcode a Cloudfront URL, but the Cloudfront distribution isn't SSL enabled and I can't load preview.html in Chrome because modestmaps.min.js is loaded over HTTP. (FYI, [Cloudfront SSL with SNI only has been free since March 2014](http://aws.amazon.com/about-aws/whats-new/2014/03/05/amazon-cloudront-announces-sni-custom-ssl/))
