### PR TITLE
Added 'pixel effect' as a Layer parameter

### DIFF
--- a/API.html
+++ b/API.html
@@ -837,7 +837,8 @@ Example layer configuration:
       "redirects": …,
       "tile height": …,
       "jpeg options": …,
-      "png options": …
+      "png options": …,
+      "pixel effect": { … }
     }
   <span class="bg">}
 }</span>
@@ -972,6 +973,14 @@ Shared layer parameters:
     <a href="http://effbot.org/imagingbook/format-png.htm">to PIL</a>.
     Valid options include <var>palette</var> (URL or filename), <var>palette256</var>
 	(boolean) and <var>optimize</var> (boolean).
+    </dd>
+
+    <dt>pixel effect</dt>
+    <dd>
+    An optional dictionary that defines an effect to be applied for all tiles
+    of this layer. Pixel effect can be any of these: <samp>blackwhite</samp>,
+    <samp>greyscale</samp>, <samp>desaturate</samp>, <samp>pixelate</samp>,
+    <samp>halftone</samp>, or <samp>blur</samp>.
     </dd>
 </dl>
 

--- a/TileStache/Config.py
+++ b/TileStache/Config.py
@@ -79,6 +79,7 @@ import Core
 import Caches
 import Providers
 import Geography
+import PixelEffects
 
 class Configuration:
     """ A complete site configuration, with a collection of Layer objects.
@@ -422,6 +423,22 @@ def _parseConfigfileLayer(layer_dict, config, dirpath):
         png_kwargs = dict([(str(k), v) for (k, v) in layer_dict['png options'].items()])
 
     #
+    # Do pixel effect
+    #
+
+    pixel_effect = None
+
+    if 'pixel effect' in layer_dict:
+        pixel_effect_dict = layer_dict['pixel effect']
+        pixel_effect_name = pixel_effect_dict.get('name')
+        if pixel_effect_name in PixelEffects.all:
+            pixel_effect_kwargs = {}
+            for k, v in pixel_effect_dict.items():
+                if k != 'name':
+                    pixel_effect_kwargs[str(k)] = float(v)
+            PixelEffectClass = PixelEffects.all[pixel_effect_name]
+            pixel_effect = PixelEffectClass(**pixel_effect_kwargs)
+    #
     # Do the provider
     #
 
@@ -447,6 +464,7 @@ def _parseConfigfileLayer(layer_dict, config, dirpath):
     layer.provider = _class(layer, **provider_kwargs)
     layer.setSaveOptionsJPEG(**jpeg_kwargs)
     layer.setSaveOptionsPNG(**png_kwargs)
+    layer.pixel_effect = pixel_effect
     
     return layer
 

--- a/TileStache/PixelEffects.py
+++ b/TileStache/PixelEffects.py
@@ -1,0 +1,172 @@
+""" Different effects that can be applied to tiles.
+
+Options are:
+
+- blackwhite:
+
+    "effect":
+    {
+        "name": "blackwhite"
+    }
+
+- greyscale:
+
+    "effect":
+    {
+        "name": "greyscale"
+    }
+
+- desaturate:
+  Has an optional parameter "factor" that defines the saturation of the image.
+  Defaults to 0.85.
+
+    "effect":
+    {
+        "name": "desaturate",
+        "factor": 0.85
+    }
+
+- pixelate:
+  Has an optional parameter "reduction" that defines how pixelated the image
+  will be (size of pixel). Defaults to 5.
+
+    "effect":
+    {
+        "name": "pixelate",
+        "factor": 5
+    }
+
+- halftone:
+
+    "effect":
+    {
+        "name": "halftone"
+    }
+
+- blur:
+  Has an optional parameter "radius" that defines the blurriness of an image.
+  Larger radius means more blurry. Defaults to 5.
+
+    "effect":
+    {
+        "name": "blur",
+        "radius": 5
+    }
+"""
+
+from PIL import Image, ImageFilter
+
+
+def put_original_alpha(original_image, new_image):
+    """ Put alpha channel of original image (if any) in the new image.
+    """
+
+    try:
+        alpha_idx = original_image.mode.index('A')
+        alpha_channel = original_image.split()[alpha_idx]
+        new_image.putalpha(alpha_channel)
+    except ValueError:
+        pass
+    return new_image
+
+
+class PixelEffect:
+    """ Base class for all pixel effects.
+        Subclasses must implement method `apply_effect`.
+    """
+
+    def __init__(self):
+        pass
+
+    def apply(self, image):
+        try:
+            image = image.image()  # Handle Providers.Verbatim tiles
+        except (AttributeError, TypeError):
+            pass
+        return self.apply_effect(image)
+
+    def apply_effect(self, image):
+        raise NotImplementedError(
+            'PixelEffect subclasses must implement method `apply_effect`.'
+        )
+
+
+class Blackwhite(PixelEffect):
+    """ Returns a black and white version of the original image.
+    """
+
+    def apply_effect(self, image):
+        new_image = image.convert('1').convert(image.mode)
+        return put_original_alpha(image, new_image)
+
+
+class Greyscale(PixelEffect):
+    """ Returns a grescale version of the original image.
+    """
+
+    def apply_effect(self, image):
+        return image.convert('LA').convert(image.mode)
+
+
+class Desaturate(PixelEffect):
+    """ Returns a desaturated version of the original image.
+        `factor` is a number between 0 and 1, where 1 results in a
+        greyscale image (no color), and 0 results in the original image.
+    """
+
+    def __init__(self, factor=0.85):
+        self.factor = min(max(factor, 0.0), 1.0)  # 0.0 <= factor <= 1.0
+
+    def apply_effect(self, image):
+        avg = image.convert('LA').convert(image.mode)
+        return Image.blend(image, avg, self.factor)
+
+
+class Pixelate(PixelEffect):
+    """ Returns a pixelated version of the original image.
+        `reduction` defines how pixelated the image will be (size of pixels).
+    """
+
+    def __init__(self, reduction=5):
+        self.reduction = max(reduction, 1)  # 1 <= reduction
+
+    def apply_effect(self, image):
+        tmp_size = (int(image.size[0] / self.reduction),
+                    int(image.size[1] / self.reduction))
+        pixelated = image.resize(tmp_size, Image.NEAREST)
+        return pixelated.resize(image.size, Image.NEAREST)
+
+
+class Halftone(PixelEffect):
+    """ Returns a halftone version of the original image.
+    """
+
+    def apply_effect(self, image):
+        cmyk = []
+        for band in image.convert('CMYK').split():
+            cmyk.append(band.convert('1').convert('L'))
+        new_image = Image.merge('CMYK', cmyk).convert(image.mode)
+        return put_original_alpha(image, new_image)
+
+
+class Blur(PixelEffect):
+    """ Returns a blurred version of the original image.
+        `radius` defines the blurriness of an image. Larger radius means more
+        blurry.
+    """
+
+    def __init__(self, radius=5):
+        self.radius = max(radius, 0)  # 0 <= radius
+
+    def apply_effect(self, image):
+        return image.filter(ImageFilter.GaussianBlur(self.radius))
+
+
+all = {
+    'blackwhite': Blackwhite,
+    'greyscale': Greyscale,
+    'desaturate': Desaturate,
+    'pixelate': Pixelate,
+    'halftone': Halftone,
+    'blur': Blur,
+}


### PR DESCRIPTION
New optional Layer parameter:

> **pixel effect**
> Optional dictionary that defines an effect to be applied for all tiles of this layer. Pixel effect can be any of these: `blackwhite`, `greyscale`, `desaturate`, `pixelate`, `halftone`, or `blur`.

``` json
{
    "cache": { ... },
    "layers": {
        "layer_name": {
            "provider": { ... },
            "pixel effect": {
                "name": "desaturate"
            }
        }
    }
}
```

Examples of resulting tiles:

**0. no pixel effect**

![sf](https://cloud.githubusercontent.com/assets/1008637/5132973/f5b1f812-70b5-11e4-9e98-f5b581852029.png)

**1. blackwhite**

![sf_blackwhite](https://cloud.githubusercontent.com/assets/1008637/5132992/21470eb8-70b6-11e4-941d-dd5c7ffcc214.png)

**2. greyscale**

![sf_greyscale](https://cloud.githubusercontent.com/assets/1008637/5132994/2bee4db8-70b6-11e4-8f2b-cc810d3e1350.png)

**3. desaturate**

![sf_desaturate](https://cloud.githubusercontent.com/assets/1008637/5132998/34e459f8-70b6-11e4-99a5-0bc704726214.png)

**4. pixelate**

![sf_pixelate](https://cloud.githubusercontent.com/assets/1008637/5133002/395e0ace-70b6-11e4-902d-b9249ba089b2.png)

**5. halftone**

![sf_halftone](https://cloud.githubusercontent.com/assets/1008637/5133004/3e205224-70b6-11e4-9f1e-120ccd83475c.png)

**6. blur**

![sf_blur](https://cloud.githubusercontent.com/assets/1008637/5133008/48d88aec-70b6-11e4-9527-8d51b5cd2cac.png)
