### PR TITLE
Clarify exception

### DIFF
--- a/TileStache/Vector/__init__.py
+++ b/TileStache/Vector/__init__.py
@@ -420,7 +420,7 @@ def _open_layer(driver_name, parameters, dirpath):
         
     elif driver_name in ('ESRI Shapefile', 'GeoJSON', 'SQLite'):
         if 'file' not in parameters:
-            raise KnownUnknown('Need at least a "file" parameter for a shapefile')
+            raise KnownUnknown('Need a "file" parameter')
     
         file_href = urljoin(dirpath, parameters['file'])
         scheme, h, file_path, q, p, f = urlparse(file_href)


### PR DESCRIPTION
If the driver name is `ESRI Shapefile`, `GeoJSON` or `SQLite` and the `file`
parameter is missing it returned the error:

```
Need at least a "file" parameter for a shapefile
```

Changed it to

```
Need a "file" parameter
```

to reflect that it applies to all three driver types and avoid confusing the user.