### PR TITLE
NoTileLeftBehind should return 404s

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -425,6 +425,7 @@ class Layer:
                     except NoTileLeftBehind, e:
                         tile = e.tile
                         save = False
+                        status_code = 404
 
                     if not self.write_cache:
                         save = False


### PR DESCRIPTION
`NoTileLeftBehind` is intended to bypass caches. It does for local caches, but it inherits the default rendering behavior, which is to return a 200 HTTP response. This means that empty tiles (not intended to be cached) are treated as cacheable by downstream requestors.