### PR TITLE
Optimize out-of-bounds tiles by pulling up bounds check

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -376,6 +376,11 @@ class Layer:
         headers = Headers([('Content-Type', mimetype)])
         body = None
 
+        if self.bounds and self.bounds.excludes(coord):
+            status_code = 404
+            del headers['Content-Type']
+            ignore_cached = True
+
         cache = self.config.cache
 
         if not ignore_cached:
@@ -477,9 +482,6 @@ class Layer:
             Note that metatiling and pass-through mode of a Provider
             are mutually exclusive options
         """
-        if self.bounds and self.bounds.excludes(coord):
-            raise NoTileLeftBehind(Image.new('RGBA', (self.dim, self.dim), (0, 0, 0, 0)))
-        
         srs = self.projection.srs
         xmin, ymin, xmax, ymax = self.envelope(coord)
         width, height = self.dim, self.dim


### PR DESCRIPTION
This eliminates the creation of exceptions when tile requests are out-of-bounds (though it retains the `except` for `NoTileLeftBehind`, as that's part of the public API).  This should represent a minor speedup and allows changes to be made to a layer's `bounds` and reflected immediately (without needing to purge any caches).

This also removes the (repetitive) creation of an empty image to serve with the 404 and instead returns an empty body.  This should represent a more substantial speedup.

The latter is arguable behavior. My feeling is that clients will have their own 404 handling in place, so including an image body is unnecessary, but some people may depend on this. If that's the case, we should just pre-generate JPG and PNG versions of the empty image on startup and return those (rather than creating and writing them on each request).