### PR TITLE
Revert "NoTileLeftBehind should return 404s"

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -425,7 +425,6 @@ class Layer:
                     except NoTileLeftBehind, e:
                         tile = e.tile
                         save = False
-                        status_code = 404
 
                     if not self.write_cache:
                         save = False


### PR DESCRIPTION
This reverts commit 1c68203468f109b603ebd6ab97fe38697158ee8e.

This was a bad idea. There are occasions where the cache should be
bypassed but the response code should be 200 (e.g. an incomplete
response being better than nothing).

See more discussion in #235 and #236.