### PR TITLE
No-cache headers

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -425,7 +425,6 @@ class Layer:
                     except NoTileLeftBehind, e:
                         tile = e.tile
                         save = False
-                        status_code = 404
 
                     if not self.write_cache:
                         save = False

--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -425,6 +425,7 @@ class Layer:
                     except NoTileLeftBehind, e:
                         tile = e.tile
                         save = False
+                        headers['Cache-Control'] = 'no-cache'
 
                     if not self.write_cache:
                         save = False


### PR DESCRIPTION
Return tiles that skip the cache as 200s and prevent downstream HTTP caches from caching (matching the local caching behavior).

Includes / depends on #238.

Refs #235, #236 