### PR TITLE
Fix error 500 when db query returns no object in the layer

### DIFF
--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -176,7 +176,10 @@ class Provider:
         
         if query not in self.columns:
             self.columns[query] = query_columns(self.dbinfo, self.srid, query, bounds)
-        
+
+        if not self.columns[query]:
+            return EmptyResponse(bounds)
+
         tolerance = self.simplify * tolerances[coord.zoom] if coord.zoom < self.simplify_until else None
         
         return Response(self.dbinfo, self.srid, query, self.columns[query], bounds, tolerance, coord.zoom, self.clip)


### PR DESCRIPTION
When you have a layer defined like this:

"myLayer": {
   ...
   "provider": {
      "class": "TileStache.Goodies.VecTiles:Provider",
      "kwargs": {
         ...
         "queries": ["SELECT  ST_Transform(sth.geom, 900913)  AS **geometry**,sth.id as id from sth WHERE sth.status=0"]
      }
   },
   ...
}

If there is no object like this in database, an error 500 is triggered:

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 180, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 168, in execute
    application_iter = app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/**init**.py", line 381, in **call**
    status_code, headers, content = requestHandler2(self.config, path_info, query_string, script_name)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/**init**.py", line 254, in requestHandler2
    status_code, headers, content = layer.getTileResponse(coord, extension)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/Core.py", line 425, in getTileResponse
    tile = self.render(coord, format)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/Core.py", line 511, in render
    tile = provider.renderTile(width, height, srs, coord)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/Goodies/VecTiles/server.py", line 182, in renderTile
    return Response(self.dbinfo, self.srid, query, self.columns[query], bounds, tolerance, coord.zoom, self.clip)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/Goodies/VecTiles/server.py", line 270, in **init**
    geo_query = build_query(srid, subquery, columns, bbox, tolerance, True, clip)
  File "/usr/local/lib/python2.7/dist-packages/TileStache-1.50.1-py2.7.egg/TileStache/Goodies/VecTiles/server.py", line 401, in build_query
    columns = ['q."%s"' % c for c in subcolumns if c not in ('**geometry**', )]
TypeError: 'NoneType' object is not iterable
