### PR TITLE
Vagrant box URL was 404. Replace with working box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "Trusty64Daily"
-  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/trusty-server-cloudimg-amd64-juju-vagrant-disk1.box"
+  config.vm.box = "ubuntu/trusty64"
 
   #config.vm.network :private_network, ip: "192.168.33.10"
 


### PR DESCRIPTION
Replaced Vagrant box since existing URL was broken. Now using Hashicorp-provided Ubuntu base box.

Here's the box it pulls now:
https://atlas.hashicorp.com/ubuntu/boxes/trusty64