### PR TITLE
Make "Expires" header RFC 1123 compliant

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -262,7 +262,7 @@ def requestHandler2(config_hint, path_info, query_string=None, script_name=''):
         
         if layer.max_cache_age is not None:
             expires = datetime.utcnow() + timedelta(seconds=layer.max_cache_age)
-            headers.setdefault('Expires', expires.strftime('%a %d %b %Y %H:%M:%S GMT'))
+            headers.setdefault('Expires', expires.strftime('%a, %d %b %Y %H:%M:%S GMT'))
             headers.setdefault('Cache-Control', 'public, max-age=%d' % layer.max_cache_age)
 
     except Core.KnownUnknown, e:


### PR DESCRIPTION
The Expires header is missing a comma after the day, which makes it non-compliant with RFC 1123, and thus prevents caching by some proxies and CDNs.