### PR TITLE
Fix compatibility issues with newer versions of PIL. Replaces #256

### DIFF
--- a/TileStache/Goodies/Providers/Composite.py
+++ b/TileStache/Goodies/Providers/Composite.py
@@ -451,13 +451,22 @@ def make_color(color):
 def _arr2img(ar):
     """ Convert Numeric array to PIL Image.
     """
-    return Image.fromstring('L', (ar.shape[1], ar.shape[0]), ar.astype(numpy.ubyte).tostring())
+    try:
+        # Numpy has a compat wrapper (numpy.ndarray.tostring)
+        return Image.frombytes('L', (ar.shape[1], ar.shape[0]), ar.astype(numpy.ubyte).tostring())
+    except AttributeError:
+        # For old versions of PIL.
+        return Image.fromstring('L', (ar.shape[1], ar.shape[0]), ar.astype(numpy.ubyte).tostring())
 
 def _img2arr(im):
     """ Convert PIL Image to Numeric array.
     """
     assert im.mode == 'L'
-    return numpy.reshape(numpy.fromstring(im.tostring(), numpy.ubyte), (im.size[1], im.size[0]))
+    try:
+        return numpy.reshape(numpy.fromstring(im.tobytes(), numpy.ubyte), (im.size[1], im.size[0]))
+    except AttributeError:
+        # For old versions of PIL
+        return numpy.reshape(numpy.fromstring(im.tostring(), numpy.ubyte), (im.size[1], im.size[0]))
 
 def _rgba2img(rgba):
     """ Convert four Numeric array objects to PIL Image.

--- a/TileStache/Goodies/Providers/GDAL.py
+++ b/TileStache/Goodies/Providers/GDAL.py
@@ -138,11 +138,19 @@ class Provider:
 
             if mask_ds is None:
                 data = ''.join([''.join(pixel) for pixel in zip(r, g, b)])
-                area = Image.fromstring('RGB', (width, height), data)
+                try:
+                    area = Image.frombytes('RGB', (width, height), data)
+                except AttributeError:
+                    # For old versions of PIL.
+                    area = Image.fromstring('RGB', (width, height), data)
             else:
                 a = mask_ds.GetRasterBand(self.maskband).GetMaskBand().ReadRaster(0, 0, width, height)
                 data = ''.join([''.join(pixel) for pixel in zip(r, g, b, a)])
-                area = Image.fromstring('RGBA', (width, height), data)
+                try:
+                    area = Image.frombytes('RGBA', (width, height), data)
+                except AttributeError:
+                    # For old versions of PIL.
+                    area = Image.fromstring('RGBA', (width, height), data)
 
         finally:
             driver.Delete('/vsimem/output')

--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -150,8 +150,11 @@ class ImageProvider:
             finally:
                 # always release the lock
                 global_mapnik_lock.release()
-
-        img = Image.fromstring('RGBA', (width, height), img.tostring())
+        try:
+            img = Image.frombytes('RGBA', (width, height), img.tobytes())
+        except AttributeError:
+            # Compatibility for old versions of PIL.
+            img = Image.fromstring('RGBA', (width, height), img.tostring())
         
         logging.debug('TileStache.Mapnik.ImageProvider.renderArea() %dx%d in %.3f from %s', width, height, time() - start_time, self.mapfile)
     

--- a/TileStache/Pixels.py
+++ b/TileStache/Pixels.py
@@ -75,7 +75,11 @@ def apply_palette(image, palette, t_index):
     """ Apply a palette array to an image, return a new image.
     """
     image = image.convert('RGBA')
-    pixels = image.tostring()
+    try:
+        pixels = image.tobytes()
+    except AttributeError:
+        # Compatibility for old versions of PIL.
+        pixels = image.tostring()
     t_value = (t_index in range(256)) and pack('!B', t_index) or None
     mapping = {}
     indexes = []
@@ -100,7 +104,12 @@ def apply_palette(image, palette, t_index):
         
         indexes.append(mapping[(r, g, b)])
 
-    output = Image.fromstring('P', image.size, ''.join(indexes))
+    try:
+        output = Image.frombytes('P', image.size, ''.join(indexes))
+    except AttributeError:
+        # Compatibility for old versions of PIL.
+        output = Image.fromstring('P', image.size, ''.join(indexes))
+
     bits = int(ceil(log(len(palette)) / log(2)))
     
     palette += [(0, 0, 0)] * (256 - len(palette))


### PR DESCRIPTION
This pull request replaces #256 by:

- Catching all the invocations of `PIL.Image.{from,to}string` to `{from,to}bytes`.
- Adding fallback wrappers for old versions of PIL.

I leave `numpy.ndarray.tostring` calls alone, because there's a compatibility wrapper in place for new versions of NumPy.