### PR TITLE
Include more than the bare essentials in sdist tarballs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,7 @@
+include API.html CHANGELOG LICENSE Makefile README.md requirements.txt runtests.sh tilestache.*
 include TileStache/Goodies/Providers/DejaVuSansMono-alphanumeric.ttf
+include Vagrantfile Vagrant/setup.sh
+recursive-include examples *.*
+recursive-include man *.1
+recursive-include tests *.*
+recursive-include www *.*


### PR DESCRIPTION
The tarballs on PyPI contains only the bare essentials to run TileStache, the tarballs on http://tilestache.org/download/ contain pretty much everything.

This PR updates `MANIFEST.in` to include most files from the git repository in the `sdist` tarballs.

These changes to `MANIFEST.in` are not strictly required if the releases get tagged in git (#265), then the tarballs can be downloaded from GitHub for use in distribution packages.