### PR TITLE
Skip tests requiring network and other unmet prerequisites.

### DIFF
--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -1,7 +1,8 @@
-from unittest import TestCase, skipIf
-from . import utils
-import memcache
 import os
+from unittest import TestCase, skipIf
+import memcache
+from . import utils
+
 
 @skipIf('OFFLINE_TESTS' in os.environ, "Offline tests only")
 class CacheTests(TestCase):

--- a/tests/cache_tests.py
+++ b/tests/cache_tests.py
@@ -1,7 +1,9 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from . import utils
 import memcache
+import os
 
+@skipIf('OFFLINE_TESTS' in os.environ, "Offline tests only")
 class CacheTests(TestCase):
     '''Tests various Cache configurations that reads from cfg file'''
 

--- a/tests/provider_tests.py
+++ b/tests/provider_tests.py
@@ -1,8 +1,10 @@
 # This Python file uses the following encoding: utf-8
+import os
 
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from . import utils
 
+@skipIf('OFFLINE_TESTS' in os.environ, "Offline tests only")
 class ProviderTests(TestCase):
     '''Tests Proxy Provider that reads from cfg file'''
 

--- a/tests/provider_tests.py
+++ b/tests/provider_tests.py
@@ -4,6 +4,7 @@ import os
 from unittest import TestCase, skipIf
 from . import utils
 
+
 @skipIf('OFFLINE_TESTS' in os.environ, "Offline tests only")
 class ProviderTests(TestCase):
     '''Tests Proxy Provider that reads from cfg file'''

--- a/tests/vectiles_tests.py
+++ b/tests/vectiles_tests.py
@@ -1,8 +1,8 @@
+import os
 from unittest import TestCase, skipIf
 from collections import namedtuple
 from math import hypot
 import json
-import os
 
 from osgeo import ogr, osr
 from shapely.geometry import Point, LineString, Polygon, MultiPolygon, asShape

--- a/tests/vectiles_tests.py
+++ b/tests/vectiles_tests.py
@@ -1,7 +1,8 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from collections import namedtuple
 from math import hypot
 import json
+import os
 
 from osgeo import ogr, osr
 from shapely.geometry import Point, LineString, Polygon, MultiPolygon, asShape
@@ -144,6 +145,7 @@ class PostGISVectorTestBase(object):
         self.conn.ExecuteSQL('DROP TABLE if exists %s' % (self.testTableName,))
 
 
+@skipIf('NO_DATABASE' in os.environ, "No database tests requested")
 class VectorProviderTest(PostGISVectorTestBase, TestCase):
     '''Various vectiles tests on top of PostGIS'''
 

--- a/tests/vector_tests.py
+++ b/tests/vector_tests.py
@@ -1,5 +1,6 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import json
+import os
 
 from osgeo import ogr
 from shapely.geometry import Point, LineString, Polygon, MultiPolygon, asShape
@@ -11,6 +12,7 @@ from . import utils
 # If you want to run them locally, create a similar PostGIS database.
 # Look at .travis.yml for details.
 
+@skipIf('NO_DATABASE' in os.environ, "No database tests requested")
 class PostGISVectorTestBase(object):
     '''
     Base Class for PostGIS Vector tests. Has methods to:

--- a/tests/vector_tests.py
+++ b/tests/vector_tests.py
@@ -12,6 +12,7 @@ from . import utils
 # If you want to run them locally, create a similar PostGIS database.
 # Look at .travis.yml for details.
 
+
 @skipIf('NO_DATABASE' in os.environ, "No database tests requested")
 class PostGISVectorTestBase(object):
     '''


### PR DESCRIPTION
Set OFFLINE_TESTS in the environment to skip tests requiring network.

Set NO_DATABASE in the environment to skip tests requiring a database.

The Debian package build environment doesn't provide network connectivity which is prohibited by the Debian Policy, nor is a database setup in the build environment.