### PR TITLE
Fix regressions due to unchanged reference to external JS file and hash removal

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -733,7 +733,7 @@ def _preview(layer):
 <html>
 <head>
     <title>TileStache Preview: %(layername)s</title>
-    <script src="http://code.modestmaps.com/tilestache/modestmaps.min.js" type="text/javascript"></script>
+    <script src="http://cdn.rawgit.com/stamen/modestmaps-js/v1.0.0-beta1/modestmaps.min.js" type="text/javascript"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <style type="text/css">
         html, body, #map {
@@ -761,6 +761,7 @@ def _preview(layer):
             new MM.DoubleClickHandler()
         ]);
         map.setCenterZoom(new com.modestmaps.Location(%(lat).6f, %(lon).6f), %(zoom)d);
+        new MM.Hash(map);
     //-->
     </script>
 </body>


### PR DESCRIPTION
Commit https://github.com/TileStache/TileStache/commit/92885db6286343fb194a28f080db8572c4b662d8#diff-69eff754f6846d301d1865dc9b2d7458 removed the ability to use the Preview function when using TileStache as a raster tile viewer.

The upgrade is calling a new `MM.TemplatedLayer` but the JS referenced in https://github.com/TileStache/TileStache/blob/master/TileStache/Core.py#L736 points to URL http://code.modestmaps.com/tilestache/modestmaps.min.js that does not contain the `TemplatedLayer` string at all. I've changed the reference to the current tagged script of ModestMap that does contain `TemplatedLayer` string.

The removal in the same commit of `new MM.Hash(map);` removed the ability when you pan in the viewer to keep center and zoom in the URL as you move.
When you use default `tilecache.cfg` file, you open http://127.0.0.1:8000/example/, then you pan, then the URL should change for example to http://127.0.0.1:8000/example/#2/37.8/-122.3
It was not working anymore.




http://127.0.0.1:8000/example/#2/37.8/-122.3