### PR TITLE
Fix preview protocol when running under https

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -742,7 +742,7 @@ def _preview(layer):
 <html>
 <head>
     <title>TileStache Preview: %(layername)s</title>
-    <script src="http://cdn.rawgit.com/stamen/modestmaps-js/v1.0.0-beta1/modestmaps.min.js" type="text/javascript"></script>
+    <script src="//cdn.rawgit.com/stamen/modestmaps-js/v1.0.0-beta1/modestmaps.min.js" type="text/javascript"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <style type="text/css">
         html, body, #map {


### PR DESCRIPTION
If the preview is served from behind an https proxy, then browsers will complain about the content being mixed-mode and not load the `modestmaps-js` script. By removing protocol from the `<script>` tag, the protocol of the current page will be used by the browser.