### PR TITLE
python3 compatibility for WSGITileServer

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -392,7 +392,10 @@ class WSGITileServer:
 
         status_code, headers, content = requestHandler2(self.config, path_info, query_string, script_name)
 
-        return self._response(start_response, status_code, str(content), headers)
+        if not isinstance(content, bytes) and not is_string_type(content):
+            content = str(content)
+
+        return self._response(start_response, status_code, content, headers)
 
     def _response(self, start_response, code, content='', headers=None):
         """


### PR DESCRIPTION
this should add compatibility for python3. my goal is to port [fff-monitoring](https://github.com/asdil12/fff-monitoring) to a single python3 app. currently it is split into a python3 part for the flask app and a python2 app for tilestach/mapnik.

the patch was tested with the following code (and seems to provide the same output on python 2.7 and python 3.5):

#### `test_server.py`

```python
from TileStache import WSGITileServer
from TileStache.Config import buildConfiguration

def get_app():
    return WSGITileServer(config=buildConfiguration({
            "cache": {
                "name": "Disk",
                "path": "tilestach_cache"
            },
            "layers": {
                "testing": {
                    "provider": {
                        "class": "TileStache.Mapnik.ImageProvider",
                        "kwargs": {
                            "mapfile": "testing.xml"
                        }
                    },
                    "metatile": {"buffer": 128},
                    "cache lifespan": 300
                },
            },
            "logging": "debug",
        })
    )

def main():
    from werkzeug.serving import run_simple
    app = get_app()
    run_simple('127.0.0.1', 8080, app)

if __name__ == '__main__':
    main()
```

#### `testing.xml`
```xml
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE Map>
<Map background-color="transparent" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
  <Style name="line_color" filter-mode="first">
    <Rule>
      <LineSymbolizer stroke-width="3" stroke="#0684c4" stroke-linecap="butt" clip="false" />
    </Rule>
  </Style>
  <Style name="shadow1">
    <Rule>
      <LineSymbolizer stroke-width="4" stroke="#333333" stroke-linecap="round" stroke-opacity="0.5" />
    </Rule>
  </Style>
  <Layer name="lines" srs="+proj=latlong +ellps=WGS84 +datum=WGS84 +no_defs">
    <StyleName>shadow1</StyleName>
    <StyleName>line_color</StyleName>
    <Datasource>
      <Parameter name="type">csv</Parameter>
      <Parameter name="file">lines.csv</Parameter>
    </Datasource>
  </Layer>
</Map>
```

#### `lines.csv`
```
WKT
"LINESTRING (0 0, 50 50)"
```

accessing `http://127.0.0.1:8080/testing/0/0/0.png` should show the same image for python2.7 and python3.5. without this patch python3.5 does not show an image and outputs the following error:

```
INFO:werkzeug:127.0.0.1 - - [02/Nov/2017 19:33:56] "GET /testing/0/0/0.png HTTP/1.1" 200 -
ERROR:werkzeug:Error on request:
Traceback (most recent call last):
  File "/home/debian/Code/TileStache/v3.5/lib/python3.5/site-packages/Werkzeug-0.11.13-py3.5.egg/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/home/debian/Code/TileStache/v3.5/lib/python3.5/site-packages/Werkzeug-0.11.13-py3.5.egg/werkzeug/serving.py", line 184, in execute
    write(data)
  File "/home/debian/Code/TileStache/v3.5/lib/python3.5/site-packages/Werkzeug-0.11.13-py3.5.egg/werkzeug/serving.py", line 164, in write
    assert isinstance(data, bytes), 'applications must write bytes'
AssertionError: applications must write bytes
```