### PR TITLE
Fix str to byte concatenation in Python 3

### DIFF
--- a/TileStache/Goodies/VecTiles/mvt.py
+++ b/TileStache/Goodies/VecTiles/mvt.py
@@ -83,9 +83,9 @@ def encode(file, features):
         
         parts.extend([_pack('>I', len(wkb)), wkb, _pack('>I', len(prop)), prop])
     
-    body = _compress(_pack('>I', len(features)) + ''.join(parts))
+    body = _compress(_pack('>I', len(features)) + b''.join(parts))
     
-    file.write('\x89MVT')
+    file.write(b'\x89MVT')
     file.write(_pack('>I', len(body)))
     file.write(body)
 

--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -392,7 +392,10 @@ class WSGITileServer:
 
         status_code, headers, content = requestHandler2(self.config, path_info, query_string, script_name)
 
-        return self._response(start_response, status_code, str(content), headers)
+        if not isinstance(content, bytes) and not is_string_type(content):
+            content = str(content)
+
+        return self._response(start_response, status_code, content, headers)
 
     def _response(self, start_response, code, content='', headers=None):
         """


### PR DESCRIPTION
Fixes error `TypeError: can't concat bytes to str` when `.mvt`s are generated with TileStache run with Python3.x