### PR TITLE
Modify so that Mapnik FontEngine API can be used with old and new Mapnik builds

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -90,7 +90,11 @@ class ImageProvider:
         self.layer = layer
         self.mapnik = None
 
-        engine = mapnik.FontEngine.instance()
+        # Maintain compatiblity between old and new Mapnik FontEngine API
+        try:
+            engine = mapnik.FontEngine.instance()
+        except AttributeError:
+            engine = mapnik.FontEngine
 
         if fonts:
             fontshref = urljoin(layer.config.dirpath, fonts)


### PR DESCRIPTION
Newer versions of the Mapnik API change the FontEngine API a little bit. This commit tweaks so that both the old and new APIs can be used.