### PR TITLE
Makes GridProvider python 3 ready.

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -283,7 +283,10 @@ class GridProvider:
 
                     for (index, fields) in self.layers:
                         datasource = self.mapnik.layers[index].datasource
-                        fields = (type(fields) is list) and map(str, fields) or datasource.fields()
+                        if isinstance(fields, list):
+                            fields = [str(f) for f in fields]
+                        else:
+                            fields = datasource.fields()
                         grid = mapnik.Grid(width, height)
                         mapnik.render_layer(self.mapnik, grid, layer=index, fields=fields)
                         grid = grid.encode('utf', resolution=self.scale, features=True)


### PR DESCRIPTION
Fork for porting lizard-nxt to python 3.