### PR TITLE
Fix 'FontEngine' has no attribute 'instance'.

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -90,7 +90,10 @@ class ImageProvider:
         self.layer = layer
         self.mapnik = None
 
-        engine = mapnik.FontEngine.instance()
+        try:
+            engine = mapnik.FontEngine.instance()
+        except AttributeError:
+            engine = mapnik.FontEngine
 
         if fonts:
             fontshref = urljoin(layer.config.dirpath, fonts)


### PR DESCRIPTION
In https://github.com/TileStache/TileStache/blob/master/TileStache/Mapnik.py#L93, TileStache calls instance() on mapnik.FontEngine:

```engine = mapnik.FontEngine.instance()```

This, however, fails with the current master and v3.0.x branch of the Python bindings for Mapnik. In the v3.0.x branch, for example, the FontEngine implementation has been changed in this commit:

https://github.com/mapnik/python-mapnik/commit/1635afe2359a0984868a47857645459c0fce44e3

This pull request addresses this issue and supports both the old and new situation.