### PR TITLE
Fix for making GridProvider python 3 ready

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -283,7 +283,10 @@ class GridProvider:
 
                     for (index, fields) in self.layers:
                         datasource = self.mapnik.layers[index].datasource
-                        fields = (type(fields) is list) and map(str, fields) or datasource.fields()
+                        if isinstance(fields, list):
+                            fields = [str(f) for f in fields]
+                        else:
+                            fields = datasource.fields()
                         grid = mapnik.Grid(width, height)
                         mapnik.render_layer(self.mapnik, grid, layer=index, fields=fields)
                         grid = grid.encode('utf', resolution=self.scale, features=True)


### PR DESCRIPTION
First of all, thanks for your work on this great project. We use this for one of our products and encountered an issue while porting our code to python 3. Would be great to have this fix merged into master so that we don't need our fork anymore.