### PR TITLE
Python 3 compat: unichar

### DIFF
--- a/TileStache/Mapnik.py
+++ b/TileStache/Mapnik.py
@@ -16,6 +16,7 @@ import logging
 import json
 
 from .py3_compat import reduce, urlopen, urljoin, urlparse, allocate_lock
+from .py3_compat import unichr
 
 # We enabled absolute_import because case insensitive filesystems
 # cause this file to be loaded twice (the name of this file

--- a/TileStache/py3_compat.py
+++ b/TileStache/py3_compat.py
@@ -22,6 +22,7 @@ try:
     from urllib.request import urlopen
     from cgi import parse_qs
     from _thread import allocate_lock
+    unichr = chr
 except ImportError:
     # Python 2
     import httplib
@@ -29,3 +30,4 @@ except ImportError:
     from urlparse import urlparse, urljoin, parse_qs, parse_qsl
     from urllib import urlopen
     from thread import allocate_lock
+    unichr = unichr


### PR DESCRIPTION
This fixes a bug having to do with "unichar" that does not exist in Python 3