### PR TITLE
More python 3 compatibility

### DIFF
--- a/TileStache/Goodies/AreaServer.py
+++ b/TileStache/Goodies/AreaServer.py
@@ -86,6 +86,6 @@ class WSGIServer (WSGITileServer):
             start_response('200 OK', headers)
             return output.getvalue()
 
-        except KnownUnknown, e:
+        except KnownUnknown as e:
             start_response('400 Bad Request', [('Content-Type', 'text/plain')])
             return str(e)

--- a/TileStache/Goodies/Caches/LimitedDisk.py
+++ b/TileStache/Goodies/Caches/LimitedDisk.py
@@ -46,7 +46,7 @@ _create_tables = """
 
 class Cache:
 
-    def __init__(self, path, limit, umask=0022):
+    def __init__(self, path, limit, umask=0o022):
         self.cachepath = path
         self.dbpath = pathjoin(self.cachepath, 'stache.db')
         self.umask = umask
@@ -167,8 +167,8 @@ class Cache:
 
         try:
             umask_old = os.umask(self.umask)
-            os.makedirs(dirname(fullpath), 0777&~self.umask)
-        except OSError, e:
+            os.makedirs(dirname(fullpath), 0o777&~self.umask)
+        except OSError as e:
             if e.errno != 17:
                 raise
         finally:
@@ -184,7 +184,7 @@ class Cache:
             os.unlink(fullpath)
             os.rename(tmp_path, fullpath)
 
-        os.chmod(fullpath, 0666&~self.umask)
+        os.chmod(fullpath, 0o666&~self.umask)
         
         stat = os.stat(fullpath)
         size = stat.st_size

--- a/TileStache/Goodies/Providers/MirrorOSM.py
+++ b/TileStache/Goodies/Providers/MirrorOSM.py
@@ -173,7 +173,7 @@ def create_tables(db, prefix, tmp_prefix):
         try:
             db.execute('CREATE TABLE %(prefix)s_%(table)s ( LIKE %(tmp_prefix)s_%(table)s )' % locals())
 
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             db.execute('ROLLBACK')
 
             if e.pgcode != '42P07':
@@ -347,7 +347,7 @@ class Provider:
 
             return ConfirmationResponse(coord, message, True)
         
-        except Exception, e:
+        except Exception as e:
             message = 'Error in tile %d/%d/%d: %s' % (coord.zoom, coord.column, coord.row, e)
             
             raise NoTileLeftBehind(ConfirmationResponse(coord, message, False))

--- a/TileStache/Goodies/StatusServer.py
+++ b/TileStache/Goodies/StatusServer.py
@@ -216,7 +216,7 @@ class WSGIServer (TileStache.WSGITileServer):
             update_status('Finished %s in %.3f seconds' % (environ['PATH_INFO'], time() - start), **self.redis_kwargs)
             return response
         
-        except Exception, e:
+        except Exception as e:
             update_status('Error: %s after %.3f seconds' % (str(e), time() - start), **self.redis_kwargs)
             raise
         


### PR DESCRIPTION
A great way to catch these issues in CI is to add something like:
```
python2 -m compileall -qf TileStache
python3 -m compileall -qf TileStache
```