### PR TITLE
Limit memcache key length for very long layer names

### DIFF
--- a/TileStache/Memcache.py
+++ b/TileStache/Memcache.py
@@ -34,6 +34,7 @@ Memcache cache parameters:
 from __future__ import absolute_import
 from time import time as _time, sleep as _sleep
 from base64 import b64encode, b64decode
+import hashlib
 
 # We enabled absolute_import because case insensitive filesystems
 # cause this file to be loaded twice (the name of this file
@@ -51,7 +52,13 @@ def tile_key(layer, coord, format, rev, key_prefix):
     """
     name = layer.name()
     tile = '%(zoom)d/%(column)d/%(row)d' % coord.__dict__
-    return str('%(key_prefix)s/%(rev)s/%(name)s/%(tile)s.%(format)s' % locals())
+    key = str('%(key_prefix)s/%(rev)s/%(name)s/%(tile)s.%(format)s' % locals())
+    
+    if len(key) < 250:
+        return key
+    
+    prefix, infix, suffix = key[:100], key[100:-100], key[-100:]
+    return prefix + hashlib.sha1(infix.encode('utf8')).hexdigest() + suffix
 
 class Cache:
     """


### PR DESCRIPTION
Memcache keys can only have 250 chars, so for extremely long layer names use a SHA-1 hash infix.

Examples:

```Python
>>> Memcache.tile_key(Layer('doof'), coord, 'GeoJSON', 1, 'prefix')
'prefix/1/doof/12/656/1582.GeoJSON'
>>> Memcache.tile_key(Layer('doof.'* 10), coord, 'GeoJSON', 1, 'prefix')
'prefix/1/doof.doof.doof.doof.doof.doof.doof.doof.doof.doof./12/656/1582.GeoJSON'
>>> Memcache.tile_key(Layer('doof.'* 100), coord, 'GeoJSON', 1, 'prefix')
'prefix/1/doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.de0f4f765ddb634728fa40a9ce028e863ff80e17bdoof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof.doof./12/656/1582.GeoJSON'

```