### PR TITLE
Allow Werkzeug versions other than 0.11.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def is_installed(name):
         return False
 
 
-requires = ['ModestMaps >=1.3.0','simplejson', 'Werkzeug == 0.11.13', 'Pillow']
+requires = ['ModestMaps >=1.3.0','simplejson', 'Werkzeug', 'Pillow']
 
 
 setup(name='TileStache',


### PR DESCRIPTION
Newer version of flask require newer versions of Werkzeug.

The warning message is as follows:

```
flask 1.0.2 has requirement Werkzeug>=0.14, but you'll have werkzeug 0.11.3 which is incompatible.
tilestache 1.51.12 has requirement Werkzeug==0.11.13, but you'll have werkzeug 0.11.3 which is incompatible.
```