### PR TITLE
Fix MVT related issues

### DIFF
--- a/TileStache/Goodies/Providers/Composite.py
+++ b/TileStache/Goodies/Providers/Composite.py
@@ -162,11 +162,7 @@ except ImportError:
     from urllib import urlopen
 from os.path import join as pathjoin
 from xml.dom.minidom import parse as parseXML
-try:
-    from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
+from io import BytesIO
 try:
     from json import loads as jsonload
 except ImportError:
@@ -329,7 +325,7 @@ class Layer:
         if self.layername:
             layer = config.layers[self.layername]
             mime, body = TileStache.getTile(layer, coord, 'png')
-            layer_img = Image.open(StringIO(body)).convert('RGBA')
+            layer_img = Image.open(BytesIO(body)).convert('RGBA')
             layer_rgba = _img2rgba(layer_img)
 
             has_layer = True
@@ -337,7 +333,7 @@ class Layer:
         if self.maskname:
             layer = config.layers[self.maskname]
             mime, body = TileStache.getTile(layer, coord, 'png')
-            mask_img = Image.open(StringIO(body)).convert('L')
+            mask_img = Image.open(BytesIO(body)).convert('L')
             mask_chan = _img2arr(mask_img).astype(numpy.float32) / 255.
 
             has_mask = True

--- a/TileStache/Goodies/Providers/MirrorOSM.py
+++ b/TileStache/Goodies/Providers/MirrorOSM.py
@@ -68,11 +68,7 @@ from tempfile import mkstemp
 from subprocess import Popen, PIPE
 from httplib import HTTPConnection
 from os.path import basename, join
-try:
-    from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
+from io import BytesIO
 from datetime import datetime
 try:
     from urllib.parse import urlparse
@@ -237,12 +233,12 @@ class ConfirmationResponse:
         else:
             bytes, color = _thumbs_down_bytes, _thumbs_down_color
         
-        thumb = Image.open(StringIO(bytes))
+        thumb = Image.open(BytesIO(bytes))
         image = Image.new('RGB', (256, 256), color)
         image.paste(thumb.resize((128, 128)), (64, 80))
         
         mapnik_url = 'http://tile.openstreetmap.org/%(zoom)d/%(column)d/%(row)d.png' % self.coord.__dict__
-        mapnik_img = Image.open(StringIO(urlopen(mapnik_url).read()))
+        mapnik_img = Image.open(BytesIO(urlopen(mapnik_url).read()))
         mapnik_img = mapnik_img.convert('L').convert('RGB')
         image = Image.blend(image, mapnik_img, .15)
         

--- a/TileStache/Goodies/VecTiles/client.py
+++ b/TileStache/Goodies/VecTiles/client.py
@@ -38,11 +38,7 @@ except ImportError:
     # Python 2
     from httplib import HTTPConnection
 from itertools import product
-try:
-    from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
+from io import BytesIO
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -141,7 +137,7 @@ def load_tile_features(lock, host, port, path_fmt, tiles, features):
 
         conn.request('GET', path, headers=head)
         resp = conn.getresponse()
-        file = StringIO(resp.read())
+        file = BytesIO(resp.read())
         
         if resp.getheader('Content-Encoding') == 'gzip':
             file = GzipFile(fileobj=file, mode='r')

--- a/TileStache/Goodies/VecTiles/mvt.py
+++ b/TileStache/Goodies/VecTiles/mvt.py
@@ -36,11 +36,7 @@ By default, encode() approximates the floating point precision of WKB geometry
 to 26 bits for a significant compression improvement and no visible impact on
 rendering at zoom 18 and lower.
 '''
-try:
-    from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
+from io import BytesIO
 from zlib import decompress as _decompress, compress as _compress
 from struct import unpack as _unpack, pack as _pack
 import json
@@ -57,7 +53,7 @@ def decode(file):
     if head != '\x89MVT':
         raise Exception('Bad head: "%s"' % head)
     
-    body = StringIO(_decompress(file.read(_next_int(file))))
+    body = BytesIO(_decompress(file.read(_next_int(file))))
     features = []
     
     for i in range(_next_int(body)):

--- a/TileStache/Goodies/VecTiles/server.py
+++ b/TileStache/Goodies/VecTiles/server.py
@@ -364,7 +364,7 @@ class EmptyResponse:
             topojson.encode(out, [], (ll.lon, ll.lat, ur.lon, ur.lat), False)
         
         elif format == 'PBF':
-            pbf.encode(out, [], None, self.bounds)
+            pbf.encode(out, [], None, layer_name='')
 
         else:
             raise ValueError(format)

--- a/TileStache/Goodies/VecTiles/wkb.py
+++ b/TileStache/Goodies/VecTiles/wkb.py
@@ -14,11 +14,7 @@ See also:
 '''
 
 from struct import unpack
-try:
-    from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
+from io import BytesIO
 
 #
 # wkbByteOrder
@@ -139,7 +135,7 @@ def approx_geometry(src, dest):
 def approximate_wkb(wkb_in):
     ''' Return an approximation of the input WKB with lower-precision geometry.
     '''
-    input, output = StringIO(wkb_in), StringIO()
+    input, output = BytesIO(wkb_in), BytesIO()
     approx_geometry(input, output)
     wkb_out = output.getvalue()
 


### PR DESCRIPTION
Use io.BytesIO instead of StringIO when convenient. See #302, #291.
Fix EmptyResponse for PBF format.