### PR TITLE
Updating CGI handler to support Python 3 byte strings.

### DIFF
--- a/TileStache/__init__.py
+++ b/TileStache/__init__.py
@@ -321,7 +321,14 @@ def cgiHandler(environ, config='./tilestache.cfg', debug=False):
         stdout.write('%s: %s\n' % (k, v))
 
     stdout.write('\n')
-    stdout.write(content)
+    stdout.flush()
+
+    # if content is actually a string, emit it as text using stdout.write
+    # else write it directly to the buffer as byte data
+    if isinstance(content, str):
+        stdout.write(content)
+    else:
+        stdout.buffer.write(content)
 
 class WSGITileServer:
     """ Create a WSGI application that can handle requests from any server that talks WSGI.


### PR DESCRIPTION
This addresses an issue that I encountered where PNG byte streams were not being emitted correctly. Treating them as normal strings resulted in Python wrapping them with `b''`, so browsers thought the image was corrupt. Emitting the byte string directly to the stdout buffer allowed the image to be rendered properly. Per the Python docs, this appears to be a change in behavior in Python 3.