### PR TITLE
Don't assume the plain 'python' executable is correct

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,7 +67,7 @@ def create_dummy_server(file_with_content, mimetype):
     #start new process using our dummy-response-server.py script
     dummy_server_file = os.path.join(current_script_dir, 'servers', 'dummy-response-server.py')
     port = find_open_port()
-    cmd = 'python %s %s "%s" "%s" ' % (dummy_server_file, str(port), file_with_content, mimetype)
+    cmd = '%s %s %s "%s" "%s" ' % (sys.executable, dummy_server_file, str(port), file_with_content, mimetype)
 
     ON_POSIX = 'posix' in sys.builtin_module_names
 


### PR DESCRIPTION
Instead, use the same executable that was used to invoke the currently running python process.

This is particularly important when running the tests using python3 when not all of the python2 prerequisites are present to invoke that script.