### PR TITLE
Unbreak serving mbtiles files

### DIFF
--- a/TileStache/MBTiles.py
+++ b/TileStache/MBTiles.py
@@ -224,9 +224,9 @@ class Provider:
         """
         mime_type, content = get_tile(self.tileset, coord)
         formats = {
-            'image/png': 'png',
-            'image/jpeg': 'jpg',
-            'application/json': 'json',
+            'image/png': 'PNG',
+            'image/jpeg': 'JPEG',
+            'application/json': 'JSON',
             'application/x-protobuf': 'pbf',
             None: None
         }


### PR DESCRIPTION
TileStache would always fail to serve requests for tiles from an mbtiles file with
formats of jpeg or png because the below exception would be raised
Requested format "JPEG" does not match tileset format "jpeg"