### PR TITLE
Fix support for raster and vector mbtiles

### DIFF
--- a/TileStache/Core.py
+++ b/TileStache/Core.py
@@ -378,6 +378,9 @@ class Layer:
 
         cache = self.config.cache
 
+        if format == 'PBF':
+            headers.add_header('Content-Encoding', 'gzip')
+
         if not ignore_cached:
             # Start by checking for a tile in the cache.
             try:


### PR DESCRIPTION
Fix support for delivering vector and raster tiles from mbtiles file. 

Merges in requests for edits made in https://github.com/TileStache/TileStache/issues/270
Obsoletes pull request https://github.com/TileStache/TileStache/pull/363 by including the same changes.

Fix support for vector tiles from mbtiles file. Set Content-Encoding header to gzip to allow browser to unzip, parse, and display vector data.

Fix bug introduced between https://github.com/TileStache/TileStache/commit/91b23656a621af4c30af9fe95749a3ca521734a9 and https://github.com/TileStache/TileStache/commit/accb57d8b61556f9f932b55d4a322f71a5ddbc2e. 
Formats in renderTile() must match those in getTypeByExtension(), otherwise requests for tiles from an mbtiles file will return a server 500 error by raising Exception('Requested format "aaa" does not match tileset format "AAA"').