### PR TITLE
Disregard case checks for file format

### DIFF
--- a/TileStache/MBTiles.py
+++ b/TileStache/MBTiles.py
@@ -266,7 +266,7 @@ class TileResponse:
         self.content = content
 
     def save(self, out, format):
-        if self.format is not None and format != self.format:
+        if self.format is not None and format.lower() != self.format.lower():
             raise Exception('Requested format "%s" does not match tileset format "%s"' % (format, self.format))
 
         out.write(self.content)


### PR DESCRIPTION
Depending on the client making the request, the file extension may be converted on uppercase, but this does not mean that the request should be invalid for a different format, e.g. 

Exception: Requested format "PNG" does not match tileset format "png"

This PR fixes this issue